### PR TITLE
Hard coded navigation for non-JS users

### DIFF
--- a/android.html
+++ b/android.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang=es>
+<html lang=en>
 	<head>
 		<title>Electrum Bitcoin Client</title>
 		
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/community.html
+++ b/community.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/console.html
+++ b/console.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/documentation.html
+++ b/documentation.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/android.html
+++ b/es/android.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/bitcoin_URIs.html
+++ b/es/bitcoin_URIs.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/community.html
+++ b/es/community.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/console.html
+++ b/es/console.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/documentation.html
+++ b/es/documentation.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/index.html
+++ b/es/index.html
@@ -49,6 +49,14 @@
 		    </nav>
 			<nav id=nav>
 				<!-- nav -->
+				<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+				<ul id=nav_en class=nav>
+					<li><a href="index.html">Home</a></li>
+					<li><a href="../download.html">Download</a></li>
+					<li><a href="documentation.html">Documentation</a></li>
+					<li><a href="community.html">Community</a></li>
+				</ul>
+				<!-- /DON'T MODIFY end -->
 			</nav>
 			<div class=header>
 				<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/offline_wallets.html
+++ b/es/offline_wallets.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/seed.html
+++ b/es/seed.html
@@ -48,6 +48,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/es/tutorials.html
+++ b/es/tutorials.html
@@ -49,6 +49,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="../download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/offline_wallets.html
+++ b/offline_wallets.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/screenshots.html
+++ b/screenshots.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/seed.html
+++ b/seed.html
@@ -45,6 +45,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>

--- a/tutorials.html
+++ b/tutorials.html
@@ -46,6 +46,14 @@
 			    </nav>
 				<nav id=nav>
 					<!-- nav -->
+					<!-- DON'T MODIFY for translations, use 'langs_nav.html' as explained in the README file -->
+					<ul id=nav_en class=nav>
+						<li><a href="index.html">Home</a></li>
+						<li><a href="download.html">Download</a></li>
+						<li><a href="documentation.html">Documentation</a></li>
+						<li><a href="community.html">Community</a></li>
+					</ul>
+					<!-- /DON'T MODIFY end -->
 				</nav>
 				<div class=header>
 					<i id=electrum_logo><img src="media/electrum_logo.png" alt="Electrum" border="none" width="70" align="top" /></i>


### PR DESCRIPTION
The hard coded navigation works in 'en' and translations, but if JS is
disable it is shown in English in sub folders, links work though as a
sub folder ('es', 'ja'...).

If JS is enable it automatically takes the nav for the selected
language, with caption well translated.

Non-JS users can now see the navigation menu, BUT not the languages
menu as it need to be changed for each lang addition, on each page, for
each translation. It would mean a unmaintainable way to keep the langs
menu. So keeping it JS-only won't hurt.
