### PR TITLE
quote the pip specifier

### DIFF
--- a/download.html
+++ b/download.html
@@ -87,7 +87,7 @@
 			<li>Install python-qt4 and pip:<br/><tt>sudo apt-get install python-qt4 python-pip</tt></li>
 			<li>On Ubuntu 13.10 do:<br/><tt>sudo apt-get install python-slowaes</tt></li>
 			<li>Install electrum:<br/>
-		        <tt style="font-size:75%">sudo pip install https://download.electrum.org/Electrum-1.9.8.tar.gz#md5=e3918fec0254267f08e41a1fb8691382</tt></li>
+		        <tt style="font-size:75%">sudo pip install 'https://download.electrum.org/Electrum-1.9.8.tar.gz#md5=e3918fec0254267f08e41a1fb8691382'</tt></li>
 			<li>Run:<br/><tt>electrum</tt></li>
 		      </ul>
 		    </td>

--- a/download.html.template
+++ b/download.html.template
@@ -87,7 +87,7 @@
 			<li>Install python-qt4 and pip:<br/><tt>sudo apt-get install python-qt4 python-pip</tt></li>
 			<li>On Ubuntu 13.10 do:<br/><tt>sudo apt-get install python-slowaes</tt></li>
 			<li>Install electrum:<br/>
-		        <tt style="font-size:75%">sudo pip install https://download.electrum.org/Electrum-##VERSION##.tar.gz#md5=##md5_tgz##</tt></li>
+		        <tt style="font-size:75%">sudo pip install 'https://download.electrum.org/Electrum-##VERSION##.tar.gz#md5=##md5_tgz##'</tt></li>
 			<li>Run:<br/><tt>electrum</tt></li>
 		      </ul>
 		    </td>


### PR DESCRIPTION
`fish` shell interprets the hash in #md5 as the start of a comment

I don't know if there are issues in any other shells, so this may be a bit out of your scope.
